### PR TITLE
Exclude files from build dir

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,5 @@
+exclude: [
+  'Gemfile',
+  'Gemfile.lock',
+  'readme.md'
+  ]


### PR DESCRIPTION
This prevents Jekyll to copy Gemfile and others to the `_site` dir. Note that by default, Travis doesn't copy dotfiles.